### PR TITLE
Floating Disc fix (+nerf)

### DIFF
--- a/bundles/bundle.properties
+++ b/bundles/bundle.properties
@@ -13,7 +13,7 @@ unit.commandustry-kirov-airship.description = Soviet bomber that packs more punc
 unit.commandustry-prism-tank.name = Prism Tank
 unit.commandustry-prism-tank.description = The Vehicle of the death. shoots long-range laser blasts that heavily damage the enemies. Weaker against buildings.
 unit.commandustry-floating-disc.name = Floating Disc
-unit.commandustry-floating-disc.description = "[accent]Disc in flight.[]" \nA weak but powerful ship, shoots short-range blasting laser and periodically release shocking electric arcs. process healing technology.
+unit.commandustry-floating-disc.description = [accent]"Disc in flight."[] \nA weak but powerful ship, fires short-range blasting laser and periodically release shocking electric arcs. Process healing technology.
 
 // for copy-pasting in the future, well, maybe
 unit.commandustry-.name =

--- a/content/units/allied/prism-tank.hjson
+++ b/content/units/allied/prism-tank.hjson
@@ -17,7 +17,7 @@ weapons: [
     y: 1
     mirror: false
     rotate: true
-    rotateSpeed: 1.8
+    rotateSpeed: 2
     reload: 125
     recoil: 2
     shootY: 4
@@ -25,12 +25,12 @@ weapons: [
     shake: 0.8
     bullet: {
       type: LaserBulletType
-      damage: 150
-      pierce: false
+      damage: 160
+      pierce: true
       buildingDamageMultiplier: 0.60
       collidesTeam: true
       recoil: 0.3
-      length: 125
+      length: 140
       colors: [88a4ff, 6f80e8, ffffff]
       lightColor: 6f80e8
       status: blasted

--- a/content/units/epsilon/floating-disc.hjson
+++ b/content/units/epsilon/floating-disc.hjson
@@ -4,13 +4,11 @@ speed: 1.6
 accel: 0.2
 drag: 0.2
 flying: true
-hitSize: 12
-range: 140
+hitSize: 12.5
+range: 90
 targetAir: false
-rotateShooting: false
 commandLimit: 11
 omniMovement: true
-faceTarget: false
 rotateSpeed: 5
 weapons: [
  {
@@ -19,7 +17,7 @@ weapons: [
  shootY: 0
  xRand: 3
  yRand: 3
- ignoreRotation: false
+ ignoreRotation: true
  reload: 60
  shootCone: 0
  shootSound: laser
@@ -27,8 +25,8 @@ weapons: [
  ejectEffect: none
  bullet: {
   type: LaserBulletType
-  damage: 70
-  pierce: false
+  damage: 60
+  pierce: true
   recoil: 0.3
   length: 85
   colors: [f3a0c6, f57dc5, ffffff]
@@ -38,11 +36,10 @@ weapons: [
   }
  }
   {
-    rotate: true
-    rotateSpeed: 3.5
     x: 0
     y: 0
     shootCone: 75
+    ignoreRotation: true
     reload: 450
     mirror: false
     shots: 10
@@ -63,8 +60,8 @@ weapons: [
 abilities: [
   {
     type: RepairFieldAbility
-    amount: 25
+    amount: 20
     reload: 300
-    range: 80
+    range: 90
   }
 ]


### PR DESCRIPTION
this fix makes floating disc rotate to where mouse is pointing, it's OP indeed, so I nerfed it a bit
also make `pierce: true` because it looks bad without it.

also remove unnecessary lines and buff Prism Tank for a specific reason